### PR TITLE
vmm: start with random local vsock port

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,8 @@ steps:
       # Build Firecracker
       - tools/devtool -y build --release
       # Upload binaries
-      - aws s3 cp build/cargo_target/x86_64-unknown-linux-musl/release/firecracker s3://flyio-builds/firecracker/${BUILDKITE_BRANCH}/firecracker --region us-east-2 &
-      - aws s3 cp build/cargo_target/x86_64-unknown-linux-musl/release/jailer s3://flyio-builds/firecracker/${BUILDKITE_BRANCH}/jailer --region us-east-2 &
+      - aws s3 cp build/cargo_target/x86_64-unknown-linux-musl/release/firecracker s3://flyio-builds/firecracker/${BUILDKITE_BRANCH}-${BUILDKITE_COMMIT}/firecracker --region us-east-2 &
+      - aws s3 cp build/cargo_target/x86_64-unknown-linux-musl/release/jailer s3://flyio-builds/firecracker/${BUILDKITE_BRANCH}-${BUILDKITE_COMMIT}/jailer --region us-east-2 &
       - wait
     agents:
       queue: "high-concurrency"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "event-manager",
  "gdbstub",
  "gdbstub_arch",
+ "getrandom 0.3.1",
  "itertools 0.14.0",
  "kvm-bindings",
  "kvm-ioctls",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -44,6 +44,7 @@ vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-bitmap"] 
 vm-superio = "0.8.0"
 vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }
 zerocopy = { version = "0.8.24" }
+getrandom = "0.3.1"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 vm-fdt = "0.3.0"

--- a/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
+++ b/src/vmm/src/devices/virtio/vsock/unix/muxer.rs
@@ -315,6 +315,12 @@ impl VsockMuxer {
         fs::set_permissions(&host_sock_path, fs::Permissions::from_mode(0o770))
             .map_err(VsockUnixBackendError::UnixConnect)?;
 
+        // Start with a random local port so we don't reuse the same ports on snapshot restore.
+        // Connections are closed across snapshot/restore, but if the guest processes
+        // haven't yet handled the error and actually called close, any connection attempts
+        // that use the same client port will be reset by the guest kernel.
+        let local_port_last = getrandom::u32().unwrap() & !(1 << 31) | (1 << 30);
+
         let mut muxer = Self {
             cid,
             host_sock,
@@ -324,7 +330,7 @@ impl VsockMuxer {
             conn_map: HashMap::with_capacity(defs::MAX_CONNECTIONS),
             listener_map: HashMap::with_capacity(defs::MAX_CONNECTIONS + 1),
             killq: MuxerKillQ::new(),
-            local_port_last: (1u32 << 30) - 1,
+            local_port_last: local_port_last,
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
         };
 


### PR DESCRIPTION
Start with a random local port so we don't reuse the same ports on snapshot restore.

Connections are closed across snapshot/restore, but if the guest processes haven't yet handled the error and actually called close on the socket, any connection attempts that use the same client port will be reset by the guest kernel.